### PR TITLE
Fix Defer bug

### DIFF
--- a/Rebus.TestHelpers/FakeRoutingApi.cs
+++ b/Rebus.TestHelpers/FakeRoutingApi.cs
@@ -55,7 +55,7 @@ namespace Rebus.TestHelpers
         public async Task Defer(string destinationAddress, TimeSpan delay, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null)
         {
             var messageSentToDestination = _factory.CreateEventGeneric<MessageDeferredToDestination>(
-                typeof(MessageSentToDestination<>),
+                typeof(MessageDeferredToDestination<>),
                 explicitlyRoutedMessage.GetType(),
                 destinationAddress,
                 delay,


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
