### PR TITLE
Fixed JSON serialization of dynamic assemblies

### DIFF
--- a/Rebus.TestHelpers/Internals/InMemorySagaStorage.cs
+++ b/Rebus.TestHelpers/Internals/InMemorySagaStorage.cs
@@ -23,7 +23,8 @@ namespace Rebus.TestHelpers.Internals
 
         readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
         {
-            TypeNameHandling = TypeNameHandling.All
+            TypeNameHandling = TypeNameHandling.All,
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full
         };
 
         internal IEnumerable<ISagaData> Instances


### PR DESCRIPTION
Hej hej! Just in time for Christmas I have some treats for you to look into over the holidays ;) Here is the backstory: At our company we use Rebus, xUnit and FakeItEasy. One of our projects has flaky tests, and everyone hates flaky tests. So after looking into it, I was able to create a smaller example that still was flaky. I'll attach it here [Flaky-v2.zip](https://github.com/rebus-org/Rebus.TestHelpers/files/5723800/Flaky-v2.zip). Based on a guess on where the problem might be I created an issue on FakeItEasy here https://github.com/FakeItEasy/FakeItEasy/issues/1794. They were also very confused but recently @blairconrad was able to find the issue and circumvent it by the change in this PR. From what I understand the issue is that Castle.Core which FakeItEasy uses sometimes creates a dynamic assembly with a public key and sometimes without a public key. And when xUnit runs tests in parallel a situation can occur where there are two dynamic assemblies with the same name but with different public keys. Newtonsoft, which Rebus.TestHelpers uses, then tries to load the assembly with Assembly.LoadWithPartialName but it fails and throws an exception. This change circumvents the issue by telling Newtonsoft to include the full assembly name when serializing. I don't know if this can have any unintended consequences! But I hope not! Do you have some tests can be run to verify that this doesn't break existing tests? Thank you very much! 


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
