### PR TITLE
Added IEnumerable<HandlerException>.ThrowIfNotEmpty extension method

### DIFF
--- a/Rebus.TestHelpers/Extensions/HandlerExceptionExtensions.cs
+++ b/Rebus.TestHelpers/Extensions/HandlerExceptionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rebus.TestHelpers.Extensions
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class HandlerExceptionExtensions
+    {
+        /// <summary>
+        /// Throws Exception if the collection of <see cref="HandlerException"/> is not empty.
+        /// </summary>
+        /// <param name="exceptions"></param>
+        /// <exception cref="AggregateException">Containing a list of exceptions inside <see cref="HandlerException"/></exception>
+        public static void ThrowIfNotEmpty(this IEnumerable<HandlerException> exceptions)
+        {
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions.Select(ex => ex.Exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
It can sometimes be hard to figure out whether your unit tests for `SagaFixtures` fails due to an exception happening inside a Rebus Saga.

To help creating leaner unit test I've added an extension method to throw exceptions happening inside the the Saga. I've found myself copying this extension into all my Rebus projects, and thought somebody else could use it as well. Cheers 🍻 

Example of how it is used:
``` csharp
using (var fixture = SagaFixture.For( () => _sut))
{
     fixture.Deliver(...);
     fixture.HandlerExceptions.ThrowIfNotEmpty();
 } 
```
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
