### PR TITLE
Updated Rebus.TestHelpers to target Rebus 7

### DIFF
--- a/Rebus.TestHelpers.Tests/Rebus.TestHelpers.Tests.csproj
+++ b/Rebus.TestHelpers.Tests/Rebus.TestHelpers.Tests.csproj
@@ -4,11 +4,11 @@
 		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="nunit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="rebus" Version="6.5.2" />
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="nunit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="rebus" Version="7.0.0" />
+		<PackageReference Include="System.Text.Json" Version="7.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.TestHelpers\Rebus.TestHelpers.csproj" />

--- a/Rebus.TestHelpers/Internals/SecondLevelDispatcher.cs
+++ b/Rebus.TestHelpers/Internals/SecondLevelDispatcher.cs
@@ -35,8 +35,8 @@ class SecondLevelDispatcher : IIncomingStep
 
             var messageId = headers.GetValue(Headers.MessageId);
 
-            _errorTracker.RegisterError(messageId, exception);
-            _errorTracker.MarkAsFinal(messageId);
+            await _errorTracker.RegisterError(messageId, exception);
+            await _errorTracker.MarkAsFinal(messageId);
         }
 
         await next();

--- a/Rebus.TestHelpers/Rebus.TestHelpers.csproj
+++ b/Rebus.TestHelpers/Rebus.TestHelpers.csproj
@@ -14,12 +14,11 @@
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="rebus" Version="[6, 7)" />
+		<PackageReference Include="rebus" Version="[7, 8)" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\artwork\little_rebusbus2_copy-500x500.png">
 			<Pack>True</Pack>
-			<PackagePath></PackagePath>
 		</None>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Fixed [#1071](https://github.com/rebus-org/Rebus.TestHelpers/issues/12)

- Updated Rebus.TestHelpers to target Rebus 7
- Updated NuGet Package Refs for the Test suite
- Boy scouted missing awaits for SecondLevelDispatcher

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
