### PR TITLE
Updated packages to avoid MissingMethodExceptions

### DIFF
--- a/Rebus.TestHelpers.Tests/Rebus.TestHelpers.Tests.csproj
+++ b/Rebus.TestHelpers.Tests/Rebus.TestHelpers.Tests.csproj
@@ -5,10 +5,10 @@
 		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+		<PackageReference Include="nunit" Version="4.4.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+		<PackageReference Include="System.Text.Json" Version="9.0.10" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.TestHelpers\Rebus.TestHelpers.csproj" />

--- a/Rebus.TestHelpers/Rebus.TestHelpers.csproj
+++ b/Rebus.TestHelpers/Rebus.TestHelpers.csproj
@@ -27,6 +27,6 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="rebus" Version="8.4.4" />
+		<PackageReference Include="rebus" Version="8.9.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated all package references in helpers + test project

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
